### PR TITLE
Feature/define roles moderator editor

### DIFF
--- a/src/auth/roles/default/default-unknown.js
+++ b/src/auth/roles/default/default-unknown.js
@@ -75,11 +75,11 @@ module.exports = function( helpers, role ) {
 		'newslettersignup:delete'   : false,
 
 		//submissions
-		'submissions:list'    : true,
-		'submissions:view'    : true,
-		'submissions:create'  : true,
-		'submissions:edit'    : true,
-		'submissions:delete'  : true,
+		'submissions:list'    : false,
+		'submissions:view'    : false,
+		'submissions:create'  : false,
+		'submissions:edit'    : false,
+		'submissions:delete'  : false,
 		// articles
 		'article:view'     : true,
 		'article:create'   : false,

--- a/src/auth/roles/default/editor.js
+++ b/src/auth/roles/default/editor.js
@@ -6,6 +6,7 @@ module.exports = function( helpers, role ) {
 		},
 		'index:view'       : true,
 		'ideas:admin'      : true,
+		'idea:admin'      : true,
 		'idea:view'        : true,
 		'idea:create'      : true,
 		'idea:edit'        : true,

--- a/src/auth/roles/default/editor.js
+++ b/src/auth/roles/default/editor.js
@@ -1,5 +1,28 @@
 module.exports = function( helpers, role ) {
 	role.action({
-		'*': true
+		'account:register' : {
+			allow   : helpers.needsToCompleteRegistration,
+			message : 'Registreren is onnodig als je bent ingelogd'
+		},
+		'index:view'       : true,
+		'ideas:admin'      : true,
+		'idea:view'        : true,
+		'idea:create'      : true,
+		'idea:edit'        : true,
+		'idea:delete'      : true,
+		'argument:view'    : true,
+		'argument:create'	 : true,
+		'argument:edit'		 : true,
+		'argument:delete'	 : true,
+		'argument:vote'    : true,
+		'ideavote:create'	 : true,
+		'image:upload'     : true,
+		'arg:add'          : true,
+		'arg:vote'         : true,
+		'arg:edit'         : true,
+		'arg:reply'        : true,
+		'arg:delete'       : true,
+		'newslettersignup:list'     : true,
+		'newslettersignup:view'	 	  : true,
 	});
 };

--- a/src/auth/roles/default/moderator.js
+++ b/src/auth/roles/default/moderator.js
@@ -6,6 +6,7 @@ module.exports = function( helpers, role ) {
 		},
 		'index:view'       : true,
 		'ideas:admin'      : true,
+		'idea:admin'       : true,
 		'idea:view'        : true,
 		'idea:create'      : true,
 		'idea:edit'        : true,

--- a/src/auth/roles/default/moderator.js
+++ b/src/auth/roles/default/moderator.js
@@ -1,5 +1,28 @@
 module.exports = function( helpers, role ) {
 	role.action({
-		'*': true
+		'account:register' : {
+			allow   : helpers.needsToCompleteRegistration,
+			message : 'Registreren is onnodig als je bent ingelogd'
+		},
+		'index:view'       : true,
+		'ideas:admin'      : true,
+		'idea:view'        : true,
+		'idea:create'      : true,
+		'idea:edit'        : true,
+		'idea:delete'      : true,
+		'argument:view'    : true,
+		'argument:create'	 : true,
+		'argument:edit'		 : true,
+		'argument:delete'	 : true,
+		'argument:vote'    : true,
+		'ideavote:create'	 : true,
+		'image:upload'     : true,
+		'arg:add'          : true,
+		'arg:vote'         : true,
+		'arg:edit'         : true,
+		'arg:reply'        : true,
+		'arg:delete'       : true,
+		'newslettersignup:list'     : true,
+		'newslettersignup:view'	 	  : true,
 	});
 };

--- a/src/routes/api/argument.js
+++ b/src/routes/api/argument.js
@@ -63,7 +63,7 @@ router.route('/')
 			.findAll({ where })
 			.then( found => {
 				return found.map( entry => {
-          
+
 					return createArgumentJSON(entry, req.user);
 				});
 			})
@@ -107,7 +107,7 @@ router.route('/')
 
 						// todo: de can dingen
 
-            
+
 
 						let result = createArgumentJSON(argument, req.user);
 						res.json(result);
@@ -239,12 +239,13 @@ router.route('/:argumentId(\\d+)/vote')
 					.then(function( argument ) {
 
 						// todo: de can dingen
+						let hasModeratorRights = (argument.user.role === 'admin' || argument.user.role === 'editor' || argument.user.role === 'moderator');
 
 						argument = argument.toJSON();
 						argument.user = {
 							nickName: argument.user.nickName || argument.user.fullName,
-							isAdmin: argument.user.role == 'admin',
-							email: req.user.role == 'admin' ? argument.user.email : '',
+							isAdmin: hasModeratorRights,
+							email: hasModeratorRights ? argument.user.email : '',
 						};
 
 						res.json(argument);
@@ -267,10 +268,11 @@ router.route('/:argumentId(\\d+)/vote')
 
 // helper functions
 function createArgumentJSON(argument, user) {
+	let hasModeratorRights = (user.role === 'admin' || user.role === 'editor' || user.role === 'moderator');
 
 	let can = {
-		edit: user.role == 'admin' || user.id == argument.user.id,
-		delete: user.role == 'admin' || user.id == argument.user.id,
+		edit: hasModeratorRights || user.id == argument.user.id,
+		delete: hasModeratorRights || user.id == argument.user.id,
 		reply: !argument.parentId,
 	};
 
@@ -281,8 +283,8 @@ function createArgumentJSON(argument, user) {
 		lastName: argument.user.lastName,
 		fullName: argument.user.fullName,
 		nickName: argument.user.nickName,
-		isAdmin: user.role == 'admin',
-		email: user.role == 'admin' ? argument.user.email : '',
+		isAdmin:  hasModeratorRights,
+		email:  hasModeratorRights ? argument.user.email : '',
 	};
 	result.createdAtText = moment(argument.createdAt).format('LLL');
 

--- a/src/routes/api/argument.js
+++ b/src/routes/api/argument.js
@@ -79,7 +79,7 @@ router.route('/')
 	.post(auth.can('argument:create'))
 	.post(function(req, res, next) {
     if (!req.idea) return next( createError(400, 'Inzending niet gevonden') );
-    if (req.idea.status != 'OPEN') return next( createError(400, 'Reactie toevoegen is niet mogelijk') );
+    if (req.idea.status != 'OPEN') return next( createError(400, 'Reactie toevoegen is niet mogelijk bij planen met status: ' + req.idea.status) );
 		next();
 	})
 	.post(function(req, res, next) {

--- a/src/routes/api/idea.js
+++ b/src/routes/api/idea.js
@@ -196,7 +196,9 @@ function filterBody(req) {
 	let filteredBody = {};
 
 	let keys;
-	if (req.user.isAdmin()) {
+	let hasModeratorRights = (req.user.role === 'admin' || req.user.role === 'editor' || req.user.role === 'moderator');
+
+	if (hasModeratorRights) {
 		keys = [ 'siteId', 'meetingId', 'userId', 'startDate', 'endDate', 'sort', 'status', 'title', 'posterImageUrl', 'summary', 'description', 'budget', 'extraData', 'location', 'modBreak', 'modBreakUserId', 'modBreakDate' ];
 	} else {
 		keys = [ 'title', 'summary', 'description', 'extraData', 'location' ];
@@ -208,7 +210,7 @@ function filterBody(req) {
 		}
 	});
 
-	if (req.user.isAdmin()) {
+	if (hasModeratorRights) {
     if (filteredBody.modBreak) {
       if ( !req.idea || req.idea.modBreak != filteredBody.modBreak ) {
         if (!req.body.modBreakUserId) filteredBody.modBreakUserId = req.user.id;
@@ -225,6 +227,8 @@ function filterBody(req) {
 }
 
 function createIdeaJSON(idea, user) {
+	let hasModeratorRights = (user.role === 'admin' || user.role === 'editor' || user.role === 'moderator');
+
 
 	let can = {
 		// edit: user.can('arg:edit', argument.idea, argument),
@@ -242,12 +246,12 @@ function createIdeaJSON(idea, user) {
 			lastName: idea.user.lastName,
 			fullName: idea.user.fullName,
 			nickName: idea.user.nickName,
-			isAdmin: user.role == 'admin',
-			email: user.role == 'admin' ? idea.user.email : '',
+			isAdmin: hasModeratorRights,
+			email: hasModeratorRights ? idea.user.email : '',
 		};
 	} else {
 		result.user = {
-			isAdmin: user.role == 'admin',
+			isAdmin: hasModeratorRights,
 		};
 	}
 	result.createdAtText = moment(idea.createdAt).format('LLL');

--- a/src/routes/api/vote.js
+++ b/src/routes/api/vote.js
@@ -44,19 +44,21 @@ router.route('*')
 	.all(function(req, res, next) {
 		if (req.method == 'GET') return next(); // nvt
 
+		let hasModeratorRights = (req.user.role === 'admin' || req.user.role === 'editor' || req.user.role === 'moderator');
+
 		if (!req.user) {
 			return next(createError(401, 'Geen gebruiker gevonden'));
 		}
 
-		if (req.site.config.votes.requiredUserRole == 'anonymous' && ( req.user.role == 'anonymous' || req.user.role == 'member' || req.user.role == 'admin' )) {
+		if (req.site.config.votes.requiredUserRole == 'anonymous' && ( req.user.role == 'anonymous' || req.user.role == 'member' || hasModeratorRights )) {
 			return next();
 		}
 
-		if (req.site.config.votes.requiredUserRole == 'member' && ( req.user.role == 'member' || req.user.role == 'admin' )) {
+		if (req.site.config.votes.requiredUserRole == 'member' && ( req.user.role == 'member' || hasModeratorRights )) {
 			return next();
 		}
 
-		if (req.site.config.votes.requiredUserRole == 'admin' && ( req.user.role == 'admin' )) {
+		if (req.site.config.votes.requiredUserRole == 'admin' && ( hasModeratorRights )) {
 			return next();
 		}
 
@@ -80,7 +82,9 @@ router.route('/')
 
   // mag je de stemmen bekijken
 	.get(function(req, res, next) {
-		if (!(req.site.config.votes.isViewable || req.user.role == 'admin')) {
+		let hasModeratorRights = (req.user.role === 'admin' || req.user.role === 'editor' || req.user.role === 'moderator');
+
+		if (!(req.site.config.votes.isViewable || hasModeratorRights)) {
 			return next(createError(403, 'Stemmen zijn niet zichtbaar'));
 		}
 		return next();


### PR DESCRIPTION
The purpose for this ticket is to create the first trial in working with editor roles the Openstad system. The communication department of Amsterdam has expressed a wish to be more involved in the Openstadsdeel democracy websites. Therefore we have a created an editor role that works in the CMS so they can help editing texts. 

The view of an editor is mainly to go in and edit the existing content. The admin user is still responsible for setting up the basic structure, therefore now sections & columns are not open for editors. We have to find out if these restrictions work in practice.

https://trello.com/c/MaUJMPDl/29-ability-to-add-editor-role-for-editing-in-cms
