### PR TITLE
allow exclude and include with AND operators

### DIFF
--- a/src/routes/api/idea.js
+++ b/src/routes/api/idea.js
@@ -36,6 +36,10 @@ router
 			req.scope.push({ method: ['filter', req.query.filters]});
 		}
 
+		if (req.query.exclude) {
+			req.scope.push({ method: ['exclude', req.query.exclude]});
+		}
+
 		if (req.query.running) {
 			req.scope.push('selectRunning');
 		}
@@ -43,8 +47,6 @@ router
 		if (req.query.includeArguments) {
 			req.scope.push({ method: ['includeArguments', req.user.id]});
 		}
-
-
 
 		if (req.query.includeTags) {
 			req.scope.push('includeTags');


### PR DESCRIPTION
allow exclude and include with AND operators on the IDEA resource route

?exclude[theme]=Green

this also works:
?exclude[theme][]=Green&exclude[theme][]=blue

Also fixed issue, making include filters with AND operator instead or
