### PR TITLE
Deleting users via API including it's resources

### DIFF
--- a/src/middleware/site.js
+++ b/src/middleware/site.js
@@ -22,7 +22,7 @@ module.exports = function( req, res, next ) {
 
   const where = { id: siteId }
 
-  db.Site
+  return db.Site
   	.findOne({ where })
   	.then(function( found ) {
   		if (!found) return next(new createError('400', 'Site niet gevonden'));


### PR DESCRIPTION
Allow for deleting a user. Set ideas, votes and arguments to deletedAt when deleting a user and delete the oauth User if there are no other sites this user is active on.