### PR TITLE
Feature/user listable and viewable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Allow viewablebyRole to be edited by the user
 * Open /stats/site/:SITE_ID/vote/total for everybody
 * Add sanitizeIfNotNull decorator to the sanitize util to prevent transforming of null into the string 'null'
+* Rename users.viewableByRole to listableByRole and fix the corresponding scope
 
 ## v0.8.0 (2020-11-02)
 * Add id & extraData to properties included in idea GET call with param includeUser=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Open /stats/site/:SITE_ID/vote/total for everybody
 * Add sanitizeIfNotNull decorator to the sanitize util to prevent transforming of null into the string 'null'
 * Rename users.viewableByRole to listableByRole and fix the corresponding scope
+* Add users.detailsViewableByRole, i.e. authorisation on fields defined per instance
 
 ## v0.8.0 (2020-11-02)
 * Add id & extraData to properties included in idea GET call with param includeUser=1

--- a/migrations/021-user-update-visibility.js
+++ b/migrations/021-user-update-visibility.js
@@ -11,6 +11,6 @@ module.exports = {
 		}
 	},
 	down: function() {
-		return db.query(`ALTER TABLE ideas DROP listableByRole;`);
+		return db.query(`ALTER TABLE users DROP listableByRole;`);
 	}
 }

--- a/migrations/021-user-update-visibility.js
+++ b/migrations/021-user-update-visibility.js
@@ -1,0 +1,16 @@
+var db = require('../src/db').sequelize;
+
+module.exports = {
+	up: function() {
+		try {
+			return db.query(`
+			  ALTER TABLE users CHANGE viewableByRole listableByRole VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL AFTER role; 
+			`);
+		} catch(e) {
+			return true;
+		}
+	},
+	down: function() {
+		return db.query(`ALTER TABLE ideas DROP listableByRole;`);
+	}
+}

--- a/migrations/022-user-detailsviewablebyrole.js
+++ b/migrations/022-user-detailsviewablebyrole.js
@@ -4,13 +4,13 @@ module.exports = {
 	up: function() {
 		try {
 			return db.query(`
-			  ALTER TABLE users ADD COLUMN viewableByRole varchar(255) NULL;
+			  ALTER TABLE users ADD detailsViewableByRole VARCHAR(255) NULL DEFAULT NULL AFTER listableByRole; 
 			`);
 		} catch(e) {
 			return true;
 		}
 	},
 	down: function() {
-		return db.query(`ALTER TABLE users DROP viewableByRole;`);
+		return db.query(`ALTER TABLE users DROP detailsViewableByRole;`);
 	}
 }

--- a/src/lib/sequelize-authorization/lib/getExtraDataConfig.js
+++ b/src/lib/sequelize-authorization/lib/getExtraDataConfig.js
@@ -84,6 +84,12 @@ module.exports = function (dataTypeJSON,  siteConfigKey) {
             let testRole = site.config && site.config[siteConfigKey] && site.config[siteConfigKey].extraData && site.config[siteConfigKey].extraData[key] && site.config[siteConfigKey].extraData[key].auth && site.config[siteConfigKey].extraData[key].auth[action+'ableBy'];
             testRole = testRole || ( self.auth && self.auth[action+'ableBy'] );
 
+            if (Array.isArray(testRole) ? testRole.includes('detailsViewableByRole') : testRole == 'detailsViewableByRole') {
+              if (self.detailsViewableByRole) {
+                testRole = self.detailsViewableByRole;
+              }
+            }
+            
             if (userHasRole(user, testRole, self.userId)) {
               result[key] = data[key];
             }

--- a/src/lib/sequelize-authorization/lib/getExtraDataConfig.js
+++ b/src/lib/sequelize-authorization/lib/getExtraDataConfig.js
@@ -1,3 +1,5 @@
+// TODO: verplaatsen; hoort niet in de generieke sequelize-authoriztion
+
 const userHasRole = require('./hasRole');
 var sanitize = require('../../../util/sanitize');
 
@@ -81,7 +83,6 @@ module.exports = function (dataTypeJSON,  siteConfigKey) {
 
             let testRole = site.config && site.config[siteConfigKey] && site.config[siteConfigKey].extraData && site.config[siteConfigKey].extraData[key] && site.config[siteConfigKey].extraData[key].auth && site.config[siteConfigKey].extraData[key].auth[action+'ableBy'];
             testRole = testRole || ( self.auth && self.auth[action+'ableBy'] );
-
 
             if (userHasRole(user, testRole, self.userId)) {
               result[key] = data[key];

--- a/src/lib/sequelize-authorization/mixins/authorize-data.js
+++ b/src/lib/sequelize-authorization/mixins/authorize-data.js
@@ -24,8 +24,15 @@ module.exports = function authorizeData(data, action, user, self, site) {
       if (self.rawAttributes[key] && self.rawAttributes[key].auth) {
         if (self.rawAttributes[key].auth.authorizeData) {
           data[key] = self.rawAttributes[key].auth.authorizeData(data[key], action, user, self, site);
+          // todo: ik denk dat hij hier moet return-en; een beetje heftige aanpassing voor even tussendoor
         } else {
           testRole = self.rawAttributes[key].auth[action+'ableBy'];
+          let detailsFieldName = 'details' + action[0].toUpperCase() + action.substring(1) + 'ableByRole';
+          if (Array.isArray(testRole) ? testRole.includes(detailsFieldName) : testRole == detailsFieldName) {
+            if (self.detailsViewableByRole) {
+              testRole = self.detailsViewableByRole;
+            }
+          }
         }
       }
 

--- a/src/lib/sequelize-authorization/mixins/authorize-data.js
+++ b/src/lib/sequelize-authorization/mixins/authorize-data.js
@@ -26,11 +26,12 @@ module.exports = function authorizeData(data, action, user, self, site) {
           data[key] = self.rawAttributes[key].auth.authorizeData(data[key], action, user, self, site);
           // todo: ik denk dat hij hier moet return-en; een beetje heftige aanpassing voor even tussendoor
         } else {
+          // dit is generieker dan de extraData versie; TODO: die moet dus ook zo generiek worden
           testRole = self.rawAttributes[key].auth[action+'ableBy'];
           let detailsFieldName = 'details' + action[0].toUpperCase() + action.substring(1) + 'ableByRole';
           if (Array.isArray(testRole) ? testRole.includes(detailsFieldName) : testRole == detailsFieldName) {
-            if (self.detailsViewableByRole) {
-              testRole = self.detailsViewableByRole;
+            if (self[detailsFieldName]) {
+              testRole = self[detailsFieldName];
             }
           }
         }

--- a/src/lib/sequelize-authorization/mixins/to-authorized-json.js
+++ b/src/lib/sequelize-authorization/mixins/to-authorized-json.js
@@ -55,7 +55,13 @@ module.exports = function toAuthorizedJSON(user) {
       if (self.rawAttributes[key].auth.authorizeData) {
         return self.rawAttributes[key].auth.authorizeData(null, 'view', user, self, self.site);
       } else {
+        // todo: waarom loopt dit niet via authorizeData
         testRole = self.rawAttributes[key].auth.viewableBy;
+        if (Array.isArray(testRole) ? testRole.includes('detailsViewableByRole') : testRole == 'detailsViewableByRole') {
+          if (self.detailsViewableByRole) {
+            testRole = self.detailsViewableByRole;
+          }
+        }
       }
     }
     testRole = testRole || ( self.auth && self.auth.viewableBy );

--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -366,6 +366,22 @@ module.exports = function( db, sequelize, DataTypes ) {
 
 				}
 			},
+      users: {
+				type: 'object',
+				subset: {
+          extraDataMustBeDefined: {
+					  type: 'boolean',
+            default: false,
+				  },
+          extraData: {
+					  type: 'object',
+				  },
+          canCreateNewUsers: {
+					  type: 'boolean',
+					  default: true,
+				  },
+				},
+      },
 			votes: {
 				type: 'object',
 				subset: {

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -173,8 +173,19 @@ module.exports = function( db, sequelize, DataTypes ) {
 
 		listableByRole: {
 			type: DataTypes.ENUM('admin', 'moderator', 'editor', 'member', 'anonymous', 'all'),
-			defaultValue: 'editor',
+			defaultValue: null,
 			auth:  {
+        viewableBy: ['editor','owner'],
+				updateableBy: ['editor', 'owner'],
+			},
+			allowNull: true,
+		},
+
+		detailsViewableByRole: {
+			type: DataTypes.ENUM('admin', 'moderator', 'editor', 'member', 'anonymous', 'all'),
+			defaultValue: null,
+			auth:  {
+        viewableBy: ['editor','owner'],
 				updateableBy: ['editor', 'owner'],
 			},
 			allowNull: true,

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -426,6 +426,7 @@ module.exports = function( db, sequelize, DataTypes ) {
         let nullCondition = `${requiredRoleEscaped} IN (${rolesEscaped})`;
         
         let where = sequelize.or(
+          // owner
           { id: userId },
           // allow when userRole is good enough
           { listableByRole: roles[userRole] || 'none' },

--- a/src/routes/api/user.js
+++ b/src/routes/api/user.js
@@ -181,10 +181,11 @@ router.route('/:userId(\\d+)')
 
 					 throw createError('Updaten niet gelukt', response);
 				})
-			 .then((json) => {
-				 //update values from API
+			.then((json) => {
 
-				 db.User
+				//update values from API
+
+				return db.User
 				  .scope(['includeSite'])
 				  .findAll({where : {
 						externalUserId: json.id,
@@ -196,54 +197,61 @@ router.route('/:userId(\\d+)')
 					  }
 					}})
 				  .then(function( users ) {
-				     const actions = [];
+				    const actions = [];
 
-				     if (users) {
-				       users.forEach((user) => {
+				    if (users) {
+				      users.forEach((user) => {
 
-                 //only update users with active site (they can be deleteds)
-                 if (user.site) {
-  				         actions.push(function() {
-  									 return new Promise((resolve, reject) => {
-  				           user
-  				            .authorizeData(data, 'update', req.user)
-  				            .update(data)
-  				            .then((result) => {
-  				              resolve();
-  				            })
-  				            .catch((err) => {
-  											console.log('err', err)
-  				              reject(err);
-  				            })
+                // only update users with active site (they can be deleteds)
+                if (user.site) {
+  				        actions.push(function() {
+  									return new Promise((resolve, reject) => {
+  				            user
+  				              .authorizeData(data, 'update', req.user)
+  				              .update(data)
+  				              .then((result) => {
+  				                resolve();
+  				              })
+  				              .catch((err) => {
+  											  console.log('err', err)
+  				                reject(err);
+  				              })
   									})}())
-                  }
+                }
 
-				       });
-				     }
+				      });
+				    }
 
-				     return Promise.all(actions)
-				        .then(() => { next(); })
-				        .catch(next)
+				    return Promise.all(actions)
+            // response has been sent; next has no meaning here
+				    // .then(() => { next(); })
+				      .catch(err => {
+                console.log(err);
+                throw(err)
+              });
 
 				  })
-				  .catch(next);
-			  })
-				.then( (result) => {
-					return db.User
-						.scope(['includeSite'])
-						.findOne({
-					 			where: { id: userId, siteId: req.params.siteId }
-								//where: { id: parseInt(req.params.userId) }
-						})
-				})
-				.then(found => {
-					if ( !found ) throw new Error('User not found');
-					res.json(found);
-				})
-			 .catch(err => {
-				 console.log(err);
-				 return next(err);
-			 });
+				  .catch(err => {
+            console.log(err);
+            throw(err)
+          });
+			})
+			.then( (result) => {
+				return db.User
+					.scope(['includeSite'])
+					.findOne({
+					 	where: { id: userId, siteId: req.params.siteId }
+						//where: { id: parseInt(req.params.userId) }
+					})
+			})
+			.then(found => {
+				if ( !found ) throw new Error('User not found');
+				res.json(found);
+			})
+			.catch(err => {
+				console.log(err);
+				return next(err);
+			});
 	})
 
 // delete idea

--- a/src/routes/api/user.js
+++ b/src/routes/api/user.js
@@ -25,15 +25,17 @@ router
 router
   .all('*', function(req, res, next) {
     req.scope = ['includeSite'];
-    req.scope.push({ method: ['onlyVisible', req.user.id, req.user.role]});
-
     next();
   });
 
 router.route('/')
   // list users
   // ----------
-  .get(auth.can('User', 'list'))
+  // .get(auth.can('User', 'list')) -> now handled by onlyListable
+  .get(function(req, res, next) {
+    req.scope.push({ method: ['onlyListable', req.user.id, req.user.role]});
+    next();
+  })
   .get(pagination.init)
   .get(function(req, res, next) {
     let { dbQuery } = req;


### PR DESCRIPTION
Branch feature/user-list-and-viewable

Zie ook https://trello.com/c/V8KXCvMh

Site config geupdate zodat die extraData velden bevat. Ik zag dat er ook een veld canCreateNewUsers zou moeten zijn. Die weordt wel gebruikt maar was niet gedefinieerd. Die ook toegevoegd.

Een migration geschreven die users.viewableByRole hernoemt naar listableByRole

De user scope onlyVisible hernoemd naar onlyListable.

Een migration voor users.detailsViewableByRole toegevoegd

Uitleg
------

idea.viewableByRole is bedacht als: iedereen mag alle ideeen bekijken, tenzij dit veld gezet is. Wat we nu willen voor users is precioes andersom: niemand mag users listen, tenzij het wordt toegestaan door de inhoud van dit veld.

Dat alleen al is een reden om het veld anders te noemen. Maar ik denk dat de volgende stap is om ideas.viewableByRole gelijk te trekken. Maar dat valt buiten de scope van wat ik nu aan het doen ben. Ik denk sowieso dat we deze velden consitent moeten doorvoeren, maar ook dat is buite de huidige scope.

null is een moeilijke waarde in deze constructie: je wilt dan eigenlijk defaulten naar de generieke waarde in het object. Dat heb ik opgelost met wat letterlijke SQL: listableByRole IS NULL AND 'editor' IN ('admin', 'moderator', 'editor', 'member', 'anonymous', 'all')

Daarmee werkt het listen van users volgens de requirements, denk ik.


Dan de zichtbare velden. Hier is viewableByRole een logische naar, ware het niet dat dat in Idea gaat om het hele object, en hier om specifieke velden. Dat vraagt dus een specifiekere naam. Ik heb gekozen voor detailsViewableByRole. Fields had gekund, maar extraData heeft weer zijn eigen subfields, en dan is dat dus weer raar.

detailsViewableByRole is nu een extra mogelijkheid in de rollen die je kunt opgeven. Dus waar je nu 'all' of ['editor', 'owner'] schrijft, kun je nu ook 'detailsViewableByRole' gebruiken, en dan checked hij tegen de inhoud van dat veld.

Dat kan nu ook naar alle andere objecten.

TODO:

- lib/sequelize-auth/mixins/authorizeData: ik denk dat er een bug in zit, rgl 28. Daar heb ik nu een commentaar regel in geschreven.
- User.onlyListable: hij kan alleen tegen een enkelvoudige listableBy
- User.onlyListable: owner wordt nu altijd toegevoegd, dat moet alleen als die in listableBy staat, maar zie vorige regel
- User.onlyListable: gelijkttrekken met Idea.onlyVisible: die is nu exclusive en deze inclusive
