### PR TITLE
fix: environment variables not overriding config

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,5 @@
-const config = require('config');
-
 require('dotenv').config();
+const config = require('config');
 
 // Env variable used by npm's `debug` package.
 process.env.DEBUG = config.logging;


### PR DESCRIPTION
By moving `require('dotenv').config();` to the top of the file we make sure environment variables are loaded before the config is being setup. This makes it possible to override the config with defined environment variables.