### PR TITLE
Feature/user anonymize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Add endpoint /user/:id/activity
+* Add endpoints /user/:id/(do|will)-anonymize(all?)
 
 ## Unreleased
 * Statuscode for error 'Already voted' was 500 and is now 403

--- a/src/lib/sequelize-authorization/lib/hasRole.js
+++ b/src/lib/sequelize-authorization/lib/hasRole.js
@@ -5,7 +5,6 @@ module.exports = function hasRole(user, minRoles, ownerId) {
   minRoles = minRoles || 'admin'; // admin can do anything
   if (!Array.isArray(minRoles)) minRoles = [minRoles];
 
-  // todo: owner
   let userRole = user && user.role;
 
   let valid = minRoles.find( minRole => {

--- a/src/models/Idea.js
+++ b/src/models/Idea.js
@@ -391,7 +391,7 @@ module.exports = function (db, sequelize, DataTypes) {
 
     hooks: {
 
-      // onderstaand is een workaround: bij een delete wordt wel de vvalidatehook aangeroepen, maar niet de beforeValidate hook. Dat lijkt een bug.
+      // onderstaand is een workaround: bij een delete wordt wel de validatehook aangeroepen, maar niet de beforeValidate hook. Dat lijkt een bug.
       beforeValidate: beforeValidateHook,
       beforeDestroy: beforeValidateHook,
 

--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -1,4 +1,5 @@
 const merge = require('merge');
+const moment = require('moment');
 
 module.exports = function (db, sequelize, DataTypes) {
 
@@ -714,6 +715,15 @@ module.exports = function (db, sequelize, DataTypes) {
         }
 
     }
+
+  Site.prototype.isVoteActive = function () {
+    let self = this;
+		let voteIsActive = self.config.votes.isActive;
+		if ( voteIsActive == null && self.config.votes.isActiveFrom && self.config.votes.isActiveTo ) {
+			voteIsActive = moment().isAfter(self.config.votes.isActiveFrom) && moment().isBefore(self.config.votes.isActiveTo)
+		}
+    return voteIsActive;
+  }
 
     Site.auth = Site.prototype.auth = {
         listableBy: 'all',

--- a/src/models/Site.js
+++ b/src/models/Site.js
@@ -716,14 +716,14 @@ module.exports = function (db, sequelize, DataTypes) {
 
     }
 
-  Site.prototype.isVoteActive = function () {
-    let self = this;
-		let voteIsActive = self.config.votes.isActive;
-		if ( voteIsActive == null && self.config.votes.isActiveFrom && self.config.votes.isActiveTo ) {
-			voteIsActive = moment().isAfter(self.config.votes.isActiveFrom) && moment().isBefore(self.config.votes.isActiveTo)
-		}
-    return voteIsActive;
-  }
+    Site.prototype.isVoteActive = function () {
+        let self = this;
+        let voteIsActive = self.config.votes.isActive;
+        if ( ( voteIsActive == null || typeof voteIsActive == 'undefined' ) && self.config.votes.isActiveFrom && self.config.votes.isActiveTo ) {
+            voteIsActive = moment().isAfter(self.config.votes.isActiveFrom) && moment().isBefore(self.config.votes.isActiveTo)
+        }
+        return voteIsActive;
+    }
 
     Site.auth = Site.prototype.auth = {
         listableBy: 'all',

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -652,8 +652,6 @@ module.exports = function (db, sequelize, DataTypes) {
 
     }
 
-  
-  
     User.auth = User.prototype.auth = {
         listableBy: 'editor',
         viewableBy: 'all',
@@ -661,13 +659,22 @@ module.exports = function (db, sequelize, DataTypes) {
         updateableBy: ['editor', 'owner'],
         deleteableBy: ['editor', 'owner'],
 
-        /*canView: function(user, self) {
-            if (self && self.viewableByRole && self.viewableByRole != 'all' ) {
-                return userHasRole(user, [ self.viewableByRole, 'owner' ], self.userId)
-            } else {
-                return true
-            }
-        },*/
+        canUpdate: function(user, self) {
+
+            // copy the base functionality
+            self = self || this;
+
+            if (!user) user = self.auth && self.auth.user;
+            if (!user || !user.role) user = { role: 'all' };
+
+            let valid = userHasRole(user, self.auth && self.auth.updateableBy, self.id);
+
+            // extra: isOwner throug user on different site
+            valid = valid || ( self.externalUserId && self.externalUserId == user.externalUserId );
+            return valid;
+
+        }
+
     }
 
     return User;

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -701,7 +701,7 @@ module.exports = function (db, sequelize, DataTypes) {
 
             let valid = userHasRole(user, self.auth && self.auth.updateableBy, self.id);
 
-            // extra: isOwner throug user on different site
+            // extra: isOwner through user on different site
             valid = valid || ( self.externalUserId && self.externalUserId == user.externalUserId );
             return valid;
 

--- a/src/routes/api/index.js
+++ b/src/routes/api/index.js
@@ -10,7 +10,6 @@ const router = express.Router({mergeParams: true});
 //router.use( bruteForce.globalMiddleware );
 //router.post( '*', bruteForce.postMiddleware );
 
-
 // dbQuery middleware
 router.use(dbQuery);
 router.use(sorting);

--- a/src/routes/api/user.js
+++ b/src/routes/api/user.js
@@ -36,6 +36,7 @@ router
     next();
   });
 
+
 router.route('/')
 // list users
 // ----------
@@ -186,6 +187,100 @@ router.route('/')
         }
       });
   });
+
+
+// anonymize user
+// --------------
+router.route('/:userId(\\d+)/:willOrDo(will|do)-anonymize(:all(all)?)')
+  .put(function (req, res, next) {
+    // this user
+    req.userId = parseInt(req.params.userId);
+    if (!req.userId) return next(new createError('404', 'User not found'))
+    return db.User
+      .scope(...req.scope)
+      .findOne({
+        where: {id: req.userId, siteId: req.params.siteId},
+        //where: { id: userId }
+      })
+      .then(found => {
+        if (!found) throw new Error('User not found');
+        req.targetUser = found;
+        req.externalUserId= found.externalUserId;
+        next();
+        return null;
+      })
+      .catch(next);
+  })
+  .put(function (req, res, next) {
+    if (!req.externalUserId) return next();
+    // this user on other sites
+    let where = { externalUserId: req.externalUserId, [Op.not]: { id: req.userId } };
+    db.User
+      .scope(...req.scope)
+      .findAll({
+        where,
+      })
+      .then(found => {
+        if (!found) return next();
+        req.linkedUsers = found;
+        next();
+        return null;
+      })
+      .catch(next);
+  })
+  .put(async function (req, res, next) {
+    console.log('ANONYMIZE USER');
+    let result;
+    if (req.params.willOrDo == 'do') {
+      result = await req.targetUser.doAnonymize();
+    } else {
+      result = await req.targetUser.willAnonymize();
+    }
+    result.users = [ result.user ];
+    delete result.user;
+    result.sites = [ result.site ];
+    delete result.site;
+    req.results = result;
+    return next();
+  })
+  .put(async function (req, res, next) {
+    if ( !(req.params.all) ) return next();
+    console.log('ANONYMIZE LINKED USERS');
+    for (const user of req.linkedUsers) {
+      let result;
+      if (req.params.willOrDo == 'do') {
+        result = await user.doAnonymize();
+      } else {
+        result = await user.willAnonymize();
+      }
+      req.results.users.push(result.user);
+      req.results.sites.push(result.site);
+      req.results.ideas = req.results.ideas.concat(result.ideas || []);
+      req.results.articles = req.results.articles.concat(result.articles || []);
+      req.results.arguments = req.results.arguments.concat(result.arguments || []);
+      req.results.votes = req.results.votes.concat(result.votes || []);
+    }
+    return next();
+  })
+  .put(function (req, res, next) {
+    if ( !(req.params.all || req.linkedUsers.length == 0) ) return next();
+    // no api users left for this oauth user, so remove the oauth user
+    console.log('REMOVE FROM OAUTH');
+    return next();
+  })
+  .get(function (req, res, next) {
+    // customized version of auth.useReqUser
+    req.results.forEach(which => {
+      req.results[which] && req.results[which].forEach( result => {
+        result.auth = result.auth || {};
+        result.auth.user = req.user;
+      });
+    });
+    return next();
+  })
+  .put(function (req, res, next) {
+    res.json(req.results);
+  })
 
 // one user
 // --------

--- a/src/routes/api/vote.js
+++ b/src/routes/api/vote.js
@@ -1,7 +1,6 @@
 const Promise     = require('bluebird');
 const express     = require('express');
 const createError = require('http-errors')
-const moment      = require('moment');
 const db          = require('../../db');
 const auth        = require('../../middleware/sequelize-authorization-middleware');
 const config      = require('config');
@@ -33,15 +32,7 @@ router.route('*')
 
   // mag er gestemd worden
 	.post(function(req, res, next) {
-		let isActive = req.site.config.votes.isActive;
-		if ( isActive == null && req.site.config.votes.isActiveFrom && req.site.config.votes.isActiveTo ) {
-			isActive = moment().isAfter(req.site.config.votes.isActiveFrom) && moment().isBefore(req.site.config.votes.isActiveTo)
-		}
-
-		if (!isActive) {
-			return next(createError(403, 'Stemmen is gesloten'));
-		}
-
+		if (!req.site.isVoteActive()) return next(createError(403, 'Stemmen is gesloten'));
 		return next();
 	})
 


### PR DESCRIPTION
## Anonymize user andpoints

```
/api/site/:SITE_ID/user/:USER_ID/will-anonymize
/api/site/:SITE_ID/user/:USER_ID/will-anonymizeall
/api/site/:SITE_ID/user/:USER_ID/do-anonymize
/api/site/:SITE_ID/user/:USER_ID/do-anonymizeall
```

do-anonymize will 
- remove all personal information(*) from the API user record for this site
- remove votes from the site if voting is active
- remove the connection to the oauth server user
- remove the user from the oauth server if this user does not exist on any other site

do-anonymizeall will do this for this user on all sites.

will-anonymize(all) returns a list of
- ideas and arguments that will be anonymized
- votes that will be removed
- users that will be anonymized
- sites related to the above

do-anonymize(all) returns the same information. That is: it returns the information from before the anonymization.

(*) firstName and lastName will be replaced with the values defined in _config.users_:
```
"users": {
  "anonymize": {
    "firstName": "Gebruiker",
    "lastName": "verwijderd"
  }
}
```