### PR TITLE
fix(oauth): encode email in path

### DIFF
--- a/src/services/oauth-api.js
+++ b/src/services/oauth-api.js
@@ -84,7 +84,7 @@ OAuthAPI.fetchUser = async function({ siteConfig, which = 'default', email, user
 
   let path = '';
   if ( userId ) path = `/api/admin/user/${userId}`;
-  if ( email  ) path = `/api/admin/users?email=${email}`;
+  if ( email  ) path = `/api/admin/users?email=${encodeURIComponent(email)}`;
   if ( token ) path = `/api/userinfo`;
 
   if (!path) throw new Error('no Find By arguments found')


### PR DESCRIPTION
User that use an email that contain special characters (like `+`) could not signup because the email was not correctly escaped inside url.

This created a bug when a user already existed in the auth api but was not found when requesting that user from the oauth api. The openstad-api would then try to create a new user which would fail because of a duplicate entry.