### PR TITLE
Remove userId from vote endpoint when user has no moderator rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## UNRELEASED
+* Remove userId from votes endpoint when user does not have moderator rights
+
 ## v0.17.0
 * Add option to anonymize only selected users at /api/site/:SITE_ID/user/:USER_ID/do-anonymizeall
 * Add automatic update of idea status after a given number of days

--- a/src/routes/api/vote.js
+++ b/src/routes/api/vote.js
@@ -144,7 +144,6 @@ router.route('/')
 			let vote = {
 				id: entry.id,
 				ideaId: entry.ideaId,
-				userId: entry.userId,
 				confirmed: entry.confirmed,
 				opinion: entry.opinion,
 				createdAt: entry.createdAt
@@ -155,6 +154,7 @@ router.route('/')
 				vote.createdAt = entry.createdAt;
 				vote.checked =  entry.checked;
 				vote.user = entry.user;
+				vote.userId = entry.userId;
 			}
       records[i] = vote
 		});


### PR DESCRIPTION
By going to /api/site/{siteId}/vote, a logged in user could get a list of all votes cast to a specific site. These votes include a userId, which in itself is useless, as they cannot fetch user data directly (/api/site/{siteId}/user/{userId?} does not provide this data).

It is however possible to retrieve all submitted ideas through /apisite/{siteId}/idea, which includes a userId for each Idea submitted. This leads to a privacy-related problem where users who have submitted an idea, can be linked to their casted votes, meaning there is no guaranteed secret of vote.

The userId is still added to the /api/site/{siteId}/vote route when the logged in user has moderator rights to ensure that moderators can still retrieve a list of all votes & generate a CSV of all votes, including the user IDs.