### PR TITLE
Feature/add client to jwt token

### DIFF
--- a/src/routes/oauth/oauth.js
+++ b/src/routes/oauth/oauth.js
@@ -231,7 +231,7 @@ router
         //check if redirect domain is allowed
         if (isAllowedRedirectDomain(redirectUrl, req.site && req.site.config && req.site.config.allowedDomains)) {
             if (redirectUrl.match('[[jwt]]')) {
-                jwt.sign({userId: req.userData.id}, config.authorization['jwt-secret'], {expiresIn: 182 * 24 * 60 * 60}, (err, token) => {
+                jwt.sign({userId: req.userData.id, client: which}, config.authorization['jwt-secret'], {expiresIn: 182 * 24 * 60 * 60}, (err, token) => {
                     if (err) return next(err)
                     req.redirectUrl = redirectUrl.replace('[[jwt]]', token);
                     return next();


### PR DESCRIPTION
Two changes have been made in the application security: first users are checked on every request against the oauth server and will be logged out if no user is found, and second the oauth server only accepts requests against the correct clientId. As a result anonymous voting no longer works.

This is fixed by adding the client name to the users jwt.